### PR TITLE
Fix parameter-handling logic in ImmutableFurl

### DIFF
--- a/aiohttpretty.py
+++ b/aiohttpretty.py
@@ -12,14 +12,17 @@ import aiohttp.streams
 class ImmutableFurl:
 
     def __init__(self, url, params=None):
-        params = params or {}
         self._url = url
         self._furl = furl.furl(url)
+        self._params = furl.furl(url).args
         self._furl.set(args={})
-        self._params = furl.furl(url).args.addlist(list(params.items()))
+
+        params = params or {}
+        for (k, v) in params.items():
+            self._params.add(k, v)
 
     def with_out_params(self):
-        return ImmutableFurl(self._url)
+        return ImmutableFurl(self.url)
 
     @property
     def url(self):

--- a/aiohttpretty.py
+++ b/aiohttpretty.py
@@ -85,7 +85,8 @@ class _AioHttPretty:
 
     @asyncio.coroutine
     def fake_request(self, method, uri, **kwargs):
-        url = ImmutableFurl(uri)
+        params = kwargs.get('params', None)
+        url = ImmutableFurl(uri, params=params)
 
         try:
             response = self.registry[(method, url)]
@@ -118,7 +119,9 @@ class _AioHttPretty:
         if any(x.get('params') for x in options.get('responses', [])):
                 raise ValueError('Cannot specify params in responses, call register multiple times.')
 
-        url = ImmutableFurl(uri, params=options.pop('params', {}))
+        params = options.pop('params', {})
+        url = ImmutableFurl(uri, params=params)
+
         self.registry[(method, url)] = options.get('responses', options)
 
     def register_json_uri(self, method, uri, **options):


### PR DESCRIPTION
ImmutableFurl's constructor has a couple of bugs with how it handles query parameters.  Query params come from two places, they can be part of the passed-in url (implicit) and they can be passed as a kwarg (explicit).  The implicit params were being discarded before being saved, and the explicit params were not being added due to a surprisingly-named utility method.  This PR makes sure to save the implicit params before stripping them off the base url, and manually adds the explicit params to the saved params dict.

We also had been omitting explicit params when building new ImmutableFurls in `register_uri` and `fake_request`.  This hadn't been triggering errors, since the explicit params were discarded anyway, and our consuming code didn't require them. 
