### PR TITLE
mock ClientResponse _loop attr to avoid crashes

### DIFF
--- a/aiohttpretty.py
+++ b/aiohttpretty.py
@@ -103,6 +103,7 @@ class _AioHttPretty:
         self.calls.append(self.make_call(method=method, uri=ImmutableFurl(uri, params=kwargs.pop('params', None)), **kwargs))
         mock_response = aiohttp.client.ClientResponse(method, uri)
         mock_response.content = _wrap_content_stream(response.get('body', 'aiohttpretty'))
+        mock_response._post_init(asyncio.get_event_loop())
 
         if response.get('auto_length'):
             defaults = {


### PR DESCRIPTION
A real ClientResponse object will have ._post_init() called on it to
supply the event loop.  The __del__ method expects an event loop to be
there and will crash if not found.  Mock it to avoid crashes when an
exception outside of aiohttpretty forces shutdown of the ClientResponse
object.

This fixes a bug in the WaterButler-python 3.5 conversion that was
causing asyncs in with pytest.raises to crash.
