### PR TITLE
[No Ticket] Fix `auto_length` for WB testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Register the specified request with aiohttpretty.  When `aiohttp.request` is cal
 
 * `status`: Affects the *response*.  The HTTP status code of the response. Defaults to 200.
 
+* `reason`: Affects the *response*. The HTTP reason phrase of the response. Defaults to `''` (an empty string).
+
+* `auto_length`: Affects the *response*. Generate the `Content-Length` header for the response based on the size of the `body`. If the same header is provided in the `headers` option, the value will be overwritten by the auto-generated value.
+
 * `headers`: Affects the *response*. A dict of headers to be included with the response.  Default is *no headers*.
 
 * `body`: Affects the *response*.  The content to be returned when `.read()` is called on the response object.  Must be either `bytes`, `str`, or `instanceOf(asyncio.StreamReader)`.

--- a/aiohttpretty.py
+++ b/aiohttpretty.py
@@ -113,8 +113,8 @@ class _AioHttPretty:
             response = self.registry[(method, url)]
         except KeyError:
             raise Exception(
-                'No URLs matching {method} {uri} with params {url.params}.'
-                ' Not making request. Go fix your test.'.format(**locals())
+                'No URLs matching {method} {uri} with params {url.params}. '
+                'Not making request. Go fix your test.'.format(**locals())
             )
 
         if isinstance(response, collections.Sequence):
@@ -130,37 +130,40 @@ class _AioHttPretty:
             **kwargs
         ))
 
-        # For how to mock ``ClientResponse`` for ``aiohttp>=3.1.0``, refer to the following link
-        # https://github.com/pnuckowski/aioresponses/blob/master/aioresponses/core.py#L129-L147
+        # For how to mock `ClientResponse` for `aiohttp>=3.1.0`, refer to the following link:
+        # https://github.com/pnuckowski/aioresponses/blob/master/aioresponses/core.py#L129-L156
+        # Here is the original commit that added support for `aiohttp>=3.1.0`:
+        # https://github.com/pnuckowski/aioresponses/commit/87cf1041179139ad78a2554713b615684b8987db
         loop = Mock()
-        # TODO: Figure out why we need the following two lines.
         loop.get_debug = Mock()
         loop.get_debug.return_value = True
+        resp_kwargs = {
+            'request_info': Mock(),
+            'writer': Mock(),
+            'continue100': None,
+            'timer': TimerNoop(),
+            'traces': [],
+            'loop': loop,
+            'session': None,
+        }
 
-        resp_kwargs = {}
-        resp_kwargs['request_info'] = Mock()
-        resp_kwargs['writer'] = Mock()
-        resp_kwargs['continue100'] = None
-        resp_kwargs['timer'] = TimerNoop()
-        resp_kwargs['traces'] = []
-        resp_kwargs['loop'] = loop
-        resp_kwargs['session'] = None
-
-        # When init `ClientResponse`, the second parameter must be of type ``yarl.URL``
-        # TODO: Integrate a property of this type to ``ImmutableFurl``.
+        # When init `ClientResponse`, the second parameter must be of type `yarl.URL`
+        # TODO: Integrate a property of this type to `ImmutableFurl`
         y_url = URL(uri)
         mock_response = ClientResponse(method, y_url, **resp_kwargs)
 
-        # TODO: can we simplify this "_wrap_content_stream()"
+        # TODO: can we simplify this `_wrap_content_stream()`
         mock_response.content = _wrap_content_stream(response.get('body', 'aiohttpretty'))
 
         # Build response headers manually
         headers = CIMultiDict(response.get('headers', {}))
         if response.get('auto_length'):
             # Calculate and overwrite the "Content-Length" header on-the-fly if Waterbutler tests
-            # call `aiohttpretty.register_uri()` with `auto_length=True`.
+            # call `aiohttpretty.register_uri()` with `auto_length=True`
             headers.update({'Content-Length': str(mock_response.content.size)})
         raw_headers = build_raw_headers(headers)
+        # Use `._headers` and `._raw_headers` for `aiohttp>=3.3.0`, compared to using `.headers` and
+        # `.raw_headers` for `3.3.0>aiohttp>=3.1.0`
         mock_response._headers = headers
         mock_response._raw_headers = raw_headers
 

--- a/aiohttpretty.py
+++ b/aiohttpretty.py
@@ -164,11 +164,9 @@ class _AioHttPretty:
         mock_response._headers = headers
         mock_response._raw_headers = raw_headers
 
-        # Set response status
+        # Set response status and reason
         mock_response.status = response.get('status', 200)
-
-        # TODO: Figure out what ``reason`` is and whether we need it.
-        # mock_response.reason = response.get('')
+        mock_response.reason = response.get('reason', '')
 
         return mock_response
 


### PR DESCRIPTION
## Ticket

No Ticket

## Purpose

### Issue

The initial [refactor](https://github.com/CenterForOpenScience/aiohttpretty/pull/9) efforts for `aiohttp3` upgrade introduced a lazy [hack](https://github.com/CenterForOpenScience/aiohttpretty/pull/9/commits/bac7e0357bcafde33a114112ab1f96d75ac338a6#diff-1db7b55050c7b9c8237323d393a9ab17L115) so that the `box` tests can pass the following failure when `mock_response.content.size` is called:

```
...
        aiohttpretty.register_uri('GET', content_url, body=b'be', auto_length=True, status=206)
>       result = await provider.download(path, range=(0,1))
tests/providers/box/test_provider.py:246:
...
        if response.get('auto_length'):
>           defaults = {'Content-Length': str(mock_response.content.size)}
E           AttributeError: 'NoneType' object has no attribute 'size'
/usr/local/lib/python3.5/site-packages/aiohttpretty.py:157: AttributeError
...
```

This hack works simply because it disables the `auto-length` option that generates the `Content-Length` header on-the-fly.  However, it breaks `dropbox` tests which require the header to exists when the `Dropbox-API-Results` header doesn't.

```
...
        aiohttpretty.register_uri('POST', url, body=b'better', auto_length=True)
>       result = await provider.download(path)
tests/providers/dropbox/test_provider.py:134:
...
multidict/_multidict.pyx:57: in multidict._multidict._Base._getone
    ???
>   ???
E   KeyError: 'dropbox-api-result'
multidict/_multidict.pyx:52: KeyError
```

### Fix

Enable `auto_length` in `.fake_request()` so that WB tests are fixed in the two following aspects.

* WB tests with `auto-length=True` no longer fails with this error `AttributeError: 'NoneType' object has no attribute 'size'` when `mock_response.content.size` is called.

* WB tests that don't provide the `Content-Length` header will receive a response containing the header with an auto-calculated value if `auto-length=True`.

## Changes

* Set response content (`mock_response.content = _wrap_content_stream(response.get('body', 'aiohttpretty'))`) before setting headers, status, etc.

* `auto-length=True` overwrites existing `Content-Length` headers.

* Enable HTTP reason phrase (`reason`) with an empty string `''` as default.

* Improved code / comments and updated `README.md` for `.fake_request()`

## Dev Testing Notes

Both `flake8` and `pytest` works.

## Deployment Notes

This PR can be merged into `develop` now since all branches other than `oathpit` uses master `aiohttpretty`.
